### PR TITLE
Add Xquik custom spec security fixture

### DIFF
--- a/tests/fixtures/xquik-social-openapi.json
+++ b/tests/fixtures/xquik-social-openapi.json
@@ -1,0 +1,106 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik Social API",
+    "version": "1.0",
+    "description": "Minimal social automation fixture for search and compose flows."
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "summary": "Search public posts",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "open source ai"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results."
+          }
+        }
+      }
+    },
+    "/api/v1/compose": {
+      "post": {
+        "operationId": "composePost",
+        "summary": "Draft a post",
+        "security": [
+          {
+            "apiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "topic"
+                ],
+                "properties": {
+                  "topic": {
+                    "type": "string",
+                    "description": "Post topic or source material."
+                  },
+                  "tone": {
+                    "type": "string",
+                    "enum": [
+                      "concise",
+                      "technical",
+                      "friendly"
+                    ],
+                    "default": "concise"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Drafted post."
+          },
+          "401": {
+            "description": "Authentication required."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      }
+    }
+  }
+}

--- a/tests/unit/custom-specs/security-scanner.test.ts
+++ b/tests/unit/custom-specs/security-scanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { SecurityScanner } from '../../../src/custom-specs/security-scanner.js';
 import { SecurityScanResult, SecurityIssue } from '../../../src/custom-specs/types.js';
+import { readFileSync } from 'fs';
 
 // Mock xss module with proper security-aware implementation
 jest.mock('xss', () => {
@@ -60,6 +61,23 @@ describe('SecurityScanner', () => {
       });
       expect(result.blocked).toBe(false);
       expect(result.scannedAt).toBeDefined();
+    });
+
+    test('should accept authenticated social API fixture', async () => {
+      const fixture = JSON.parse(
+        readFileSync('tests/fixtures/xquik-social-openapi.json', 'utf8')
+      );
+
+      const result = await securityScanner.scanSpec(fixture);
+
+      expect(result.issues).toHaveLength(0);
+      expect(result.summary).toEqual({
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0
+      });
+      expect(result.blocked).toBe(false);
     });
 
     test('should detect script injection in descriptions', async () => {


### PR DESCRIPTION
## Summary
- add a compact Xquik Social API OpenAPI fixture for custom-spec coverage
- cover header API key auth and operation-level auth metadata
- add a SecurityScanner regression to confirm the fixture stays clean

## Duplicate Gate
- no existing Xquik PRs or issues found in this repo
- default branch had no Xquik or x-twitter-scraper entry

## Validation
- npm ci
- focused SecurityScanner Jest test passed
- git diff check passed
- JSON fixture parsed with python json.tool